### PR TITLE
Add copy module map step to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,9 @@ cp GcUniversal/libgcuniversalrootless.tbd "${THEOS}/lib/iphone/rootless/libgcuni
 mkdir -p "${THEOS}/include/GcUniversal"
 cp GcUniversal/*.h "${THEOS}/include/GcUniversal/"
 
+# Copy the module map
+cp GcUniversal/module.modulemap "${THEOS}/include/GcUniversal/"
+
 # We're done
 set +v
 


### PR DESCRIPTION
The `module.modulemap` file was previously not copied by the install script. This file is required when importing as a module.